### PR TITLE
Add GOLDPEPE (24K Gold Pepe) to Solana Wormhole token list

### DIFF
--- a/src/utils/solana_wormhole_tokens.json
+++ b/src/utils/solana_wormhole_tokens.json
@@ -1,4 +1,11 @@
-{
+"GOLDPEPE": {
+  "symbol": "GOLDPEPE",
+  "name": "24K Gold Pepe",
+  "address": "FA532HAN5BVwNsKMxXxj8gBWQj8QL2p8x8zNn3Mipump",
+  "origin": "sol",
+  "sourceAddress": "FA532HAN5BVwNsKMxXxj8gBWQj8QL2p8x8zNn3Mipump",
+  "decimals": 6
+},
   "1INCH": {
     "symbol": "1INCH",
     "name": "1INCH Token (Wormhole)",


### PR DESCRIPTION
This PR adds 24K Gold Pepe (GOLDPEPE) to the Solana Wormhole token list.

- Symbol: GOLDPEPE
- Name: 24K Gold Pepe
- Address (Solana): FA532HAN5BVwNsKMxXxj8gBWQj8QL2p8x8zNn3Mipump
- Decimals: 6
- Origin: Solana